### PR TITLE
Enable admin user in ArgoCD configuration

### DIFF
--- a/09_security_scaling/README.md
+++ b/09_security_scaling/README.md
@@ -168,7 +168,7 @@ Create: [argocd-user-cm.yaml](argocd-user-cm.yaml)
 * Similarly, You can enable `admin` user, using:
 
   ```bash
-  kubectl patch -n argocd configmap argocd-cm --patch='{"data":{"admin.enabled": "false"}}'
+  kubectl patch -n argocd configmap argocd-cm --patch='{"data":{"admin.enabled": "true"}}'
   ```
 
 ### Example RBAC Policy


### PR DESCRIPTION
command mistake repaired for enabling admin account

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ArgoCD configuration example in the security and scaling guide to reflect the current approach for admin account configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->