### PR TITLE
Change installation command in README

### DIFF
--- a/07_argocd_image_updater/README.md
+++ b/07_argocd_image_updater/README.md
@@ -108,7 +108,7 @@ argocd-image-updater.argoproj.io/image-list: chai-app=<your-dockerhub-username>/
 Install into the `argocd` namespace:
 
 ```bash
-kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/manifests/install.yaml
+kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/stable/config/install.yaml
 ```
 
 Verify pod is running:


### PR DESCRIPTION
Updated installation command in README to use config manifest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated installation instructions to reference the new source location for deployment manifests, ensuring users access the correct installation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->